### PR TITLE
slim dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,20 @@
-# Build stage
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
-WORKDIR /app
+WORKDIR /src
 
-# Install git and ca-certificates (needed for go mod download)
-RUN apk add --no-cache git ca-certificates
-
-# Copy go mod files
 COPY go.mod go.sum ./
-
-# Download dependencies
 RUN go mod download
 
-# Copy source code
 COPY . .
 
-# Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main ./cmd/server
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -o /out/server ./cmd/server
 
-# Final stage
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian12:nonroot
 
-# Install ca-certificates for HTTPS requests
-RUN apk --no-cache add ca-certificates
+COPY --from=builder /out/server /server
 
-WORKDIR /root/
-
-# Copy the binary from builder stage
-COPY --from=builder /app/main .
-
-# Expose port
 EXPOSE 8080
-
-# Run the application
-CMD ["./main"] 
+USER nonroot:nonroot
+ENTRYPOINT ["/server"]


### PR DESCRIPTION
- bump builder to go 1.24 to match go.mod (1.21 was failing)
- final image is distroless static nonroot, ~18mb
- strip symbol tables with -s -w