### PR TITLE
drop status from response

### DIFF
--- a/internal/campaigns/campaign_store_test.go
+++ b/internal/campaigns/campaign_store_test.go
@@ -54,7 +54,7 @@ func TestGetMatchingCampaigns(t *testing.T) {
 		{
 			name:     "No matches for web",
 			app:      "com.test",
-			country:  "us",
+			country:  "zz",
 			os:       "web",
 			expected: []string{},
 		},

--- a/internal/delivery/handler_test.go
+++ b/internal/delivery/handler_test.go
@@ -122,7 +122,7 @@ func TestHandleDeliveryRequest_Integration(t *testing.T) {
 		},
 		{
 			name:           "No matches - should return 204",
-			query:          "?app=com.test&country=us&os=web",
+			query:          "?app=com.test&country=zz&os=web",
 			expectedStatus: http.StatusNoContent,
 		},
 		{
@@ -200,13 +200,12 @@ func TestHandleDeliveryRequest_ResponseFormat(t *testing.T) {
 	err = json.Unmarshal(w.Body.Bytes(), &campaigns)
 	require.NoError(t, err)
 
-	// Verify campaign structure
 	for _, campaign := range campaigns {
 		assert.NotEmpty(t, campaign.ID)
 		assert.NotEmpty(t, campaign.Name)
 		assert.NotEmpty(t, campaign.Img)
 		assert.NotEmpty(t, campaign.CTA)
-		assert.Equal(t, "ACTIVE", campaign.Status)
+		assert.Empty(t, campaign.Status, "status must not leak to the wire")
 	}
 }
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -5,7 +5,7 @@ type Campaign struct {
 	Name   string `json:"name"`
 	Img    string `json:"img"`
 	CTA    string `json:"cta"`
-	Status string `json:"status"`
+	Status string `json:"-"`
 }
 
 type TargetingRule struct {


### PR DESCRIPTION
- assignment spec is {cid,name,img,cta}; status was leaking into v1 + v2
- json:"-" on Campaign.Status keeps it usable internally
- the no-match integration tests asserted 0 results for app=com.test&country=us&os=web, but spotify (us, no os filter) actually matches — fixed the query to country=zz so it genuinely matches nothing