### PR TITLE
structured logs and readyz

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -23,55 +25,40 @@ import (
 )
 
 func main() {
-	// Get database connection string from environment or use default
-	dbConnStr := getDBConnectionString()
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
 
-	// Connect to PostgreSQL
-	db, err := sql.Open("postgres", dbConnStr)
+	db, err := sql.Open("postgres", dbConnString())
 	if err != nil {
-		log.Fatalf("❌ Failed to connect to DB: %v", err)
+		logger.Error("open db", "err", err)
+		os.Exit(1)
 	}
 	defer db.Close()
 
-	// Test database connection
-	if err := db.Ping(); err != nil {
-		log.Fatalf("❌ Failed to ping DB: %v", err)
+	if err := pingWithRetry(db, 10, time.Second); err != nil {
+		logger.Error("ping db", "err", err)
+		os.Exit(1)
 	}
-	log.Println("✅ Database connection established")
+	logger.Info("db connected")
 
-	// Create router with middleware
 	r := chi.NewRouter()
-
-	// Add middleware
-	r.Use(middleware.Logger)
-	r.Use(middleware.Recoverer)
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
-	r.Use(middleware.Timeout(60 * time.Second))
+	r.Use(middleware.Recoverer)
+	r.Use(middleware.Timeout(15 * time.Second))
 
-	// Health check
-	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"healthy","timestamp":"` + time.Now().Format(time.RFC3339) + `"}`))
-	})
-
-	// Prometheus metrics endpoint
+	r.Get("/healthz", liveness)
+	r.Get("/readyz", readiness(db))
 	r.Handle("/metrics", promhttp.Handler())
 
-	// API routes v1 (legacy/tests)
 	r.Route("/v1", func(r chi.Router) {
 		r.Get("/delivery", delivery.HandleDeliveryRequest(db))
 	})
 
-	// API routes v2 (go-kit)
 	svc := service.NewDeliveryService(db)
 	eps := endpoints.Endpoints{Delivery: endpoints.MakeDeliveryEndpoint(svc)}
-	r.Route("/", func(r chi.Router) {
-		transport.RegisterV2Routes(r, eps)
-	})
+	transport.RegisterV2Routes(r, eps)
 
-	// Create server
 	srv := &http.Server{
 		Addr:         ":8080",
 		Handler:      r,
@@ -80,49 +67,79 @@ func main() {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// Start server in a goroutine
 	go func() {
-		log.Printf("🚀 Server starting on :8080")
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("❌ Server failed to start: %v", err)
+		logger.Info("server listening", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("listen", "err", err)
+			os.Exit(1)
 		}
 	}()
 
-	// Wait for interrupt signal to gracefully shutdown the server
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
+	logger.Info("shutdown signal received")
 
-	log.Println("🛑 Server shutting down...")
-
-	// Create a deadline for server shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-
-	// Attempt graceful shutdown
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatalf("❌ Server forced to shutdown: %v", err)
+		logger.Error("shutdown", "err", err)
+		os.Exit(1)
 	}
-
-	log.Println("✅ Server exited gracefully")
+	logger.Info("shutdown complete")
 }
 
-func getDBConnectionString() string {
-	// Get database configuration from environment variables
-	host := getEnv("DB_HOST", "localhost")
-	port := getEnv("DB_PORT", "5432")
-	dbname := getEnv("DB_NAME", "targeting_db")
-	user := getEnv("DB_USER", "postgres")
-	password := getEnv("DB_PASSWORD", "password")
-	sslmode := getEnv("DB_SSL_MODE", "disable")
-
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		user, password, host, port, dbname, sslmode)
+func liveness(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-func getEnv(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
+func readiness(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		if err := db.PingContext(ctx); err != nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"status": "db_unreachable"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
 	}
-	return defaultValue
+}
+
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func pingWithRetry(db *sql.DB, attempts int, base time.Duration) error {
+	var err error
+	for i := 0; i < attempts; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		err = db.PingContext(ctx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(base * time.Duration(i+1))
+	}
+	return err
+}
+
+func dbConnString() string {
+	return fmt.Sprintf(
+		"postgres://%s:%s@%s:%s/%s?sslmode=%s",
+		getEnv("DB_USER", "postgres"),
+		getEnv("DB_PASSWORD", "password"),
+		getEnv("DB_HOST", "localhost"),
+		getEnv("DB_PORT", "5432"),
+		getEnv("DB_NAME", "targeting_db"),
+		getEnv("DB_SSL_MODE", "disable"),
+	)
+}
+
+func getEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
 }

--- a/internal/delivery/handler.go
+++ b/internal/delivery/handler.go
@@ -3,10 +3,12 @@ package delivery
 import (
 	"database/sql"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/campaigns"
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/metrics"
@@ -16,35 +18,32 @@ import (
 func HandleDeliveryRequest(db *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-
-		// Set response headers
+		reqID := middleware.GetReqID(r.Context())
 		w.Header().Set("Content-Type", "application/json")
 
-		// Validate request parameters
 		req, errMsg := validateParams(r)
 		if errMsg != "" {
-			log.Printf("❌ Invalid request parameters: %s", errMsg)
 			w.WriteHeader(http.StatusBadRequest)
 			metrics.ObserveRequest("bad_request", time.Since(start).Seconds())
-			json.NewEncoder(w).Encode(map[string]string{"error": errMsg})
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": errMsg})
 			return
 		}
 
-		// Get matching campaigns
 		matched, err := campaigns.GetMatchingCampaigns(db, req.App, req.Country, req.OS)
 		if err != nil {
-			log.Printf("❌ Database query failed: %v", err)
+			slog.ErrorContext(r.Context(), "delivery query failed", "req_id", reqID, "err", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			metrics.ObserveRequest("error", time.Since(start).Seconds())
-			json.NewEncoder(w).Encode(map[string]string{"error": "internal server error"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal server error"})
 			return
 		}
 
-		// Log request details
-		log.Printf("📊 Request: app=%s, country=%s, os=%s, matches=%d, duration=%v",
-			req.App, req.Country, req.OS, len(matched), time.Since(start))
+		slog.InfoContext(r.Context(), "delivery",
+			"req_id", reqID,
+			"app", req.App, "country", req.Country, "os", req.OS,
+			"matches", len(matched), "duration_ms", time.Since(start).Milliseconds(),
+		)
 
-		// Return appropriate response
 		if len(matched) == 0 {
 			w.WriteHeader(http.StatusNoContent)
 			metrics.ObserveRequest("no_content", time.Since(start).Seconds())
@@ -54,7 +53,7 @@ func HandleDeliveryRequest(db *sql.DB) http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 		metrics.ObserveRequest("ok", time.Since(start).Seconds())
 		if err := json.NewEncoder(w).Encode(matched); err != nil {
-			log.Printf("❌ Failed to encode response: %v", err)
+			slog.ErrorContext(r.Context(), "encode response", "req_id", reqID, "err", err)
 		}
 	}
 }
@@ -76,7 +75,7 @@ func validateParams(r *http.Request) (models.DeliveryRequest, string) {
 	}
 
 	return models.DeliveryRequest{
-		App:     app,
+		App:     strings.ToLower(app),
 		Country: strings.ToLower(country),
 		OS:      strings.ToLower(os),
 	}, ""

--- a/internal/delivery/handler_test.go
+++ b/internal/delivery/handler_test.go
@@ -52,7 +52,7 @@ func TestValidateParams(t *testing.T) {
 		{
 			name:     "Case insensitive parameters",
 			query:    "?app=COM.TEST&country=US&os=ANDROID",
-			expected: models.DeliveryRequest{App: "COM.TEST", Country: "us", OS: "android"},
+			expected: models.DeliveryRequest{App: "com.test", Country: "us", OS: "android"},
 			hasError: false,
 		},
 		{


### PR DESCRIPTION
- swap log.Printf+emojis for slog json
- /healthz is liveness only; new /readyz pings the db with a 2s timeout
- ping with retry on boot so a slow db doesn't crashloop
- lowercase app at the boundary so logs match what the query sees