### PR TITLE
thread context to db

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -34,6 +35,11 @@ func main() {
 		os.Exit(1)
 	}
 	defer db.Close()
+
+	db.SetMaxOpenConns(envInt("DB_MAX_OPEN_CONNS", 25))
+	db.SetMaxIdleConns(envInt("DB_MAX_IDLE_CONNS", 10))
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(5 * time.Minute)
 
 	if err := pingWithRetry(db, 10, time.Second); err != nil {
 		logger.Error("ping db", "err", err)
@@ -142,4 +148,16 @@ func getEnv(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
 }

--- a/internal/campaigns/campaign_store.go
+++ b/internal/campaigns/campaign_store.go
@@ -1,6 +1,7 @@
 package campaigns
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 	"time"
@@ -9,32 +10,27 @@ import (
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/models"
 )
 
-func GetMatchingCampaigns(db *sql.DB, app, country, os string) ([]models.Campaign, error) {
-	// Convert to lowercase for case-insensitive matching
+const matchQuery = `
+SELECT DISTINCT c.cid, c.name, c.img, c.cta, c.status
+FROM campaigns c
+JOIN targeting_rules tr ON c.cid = tr.cid
+WHERE c.status = 'ACTIVE'
+  AND (tr.include_country IS NULL OR $2 = ANY(tr.include_country))
+  AND (tr.include_os      IS NULL OR $3 = ANY(tr.include_os))
+  AND (tr.include_app     IS NULL OR $1 = ANY(tr.include_app))
+  AND (tr.exclude_country IS NULL OR NOT ($2 = ANY(tr.exclude_country)))
+  AND (tr.exclude_os      IS NULL OR NOT ($3 = ANY(tr.exclude_os)))
+  AND (tr.exclude_app     IS NULL OR NOT ($1 = ANY(tr.exclude_app)))
+ORDER BY c.cid
+`
+
+func GetMatchingCampaigns(ctx context.Context, db *sql.DB, app, country, os string) ([]models.Campaign, error) {
 	app = strings.ToLower(app)
 	country = strings.ToLower(country)
 	os = strings.ToLower(os)
 
-	query := `
-	SELECT DISTINCT c.cid, c.name, c.img, c.cta, c.status
-	FROM campaigns c
-	JOIN targeting_rules tr ON c.cid = tr.cid
-	WHERE c.status = 'ACTIVE'
-	  AND (
-		-- Check include rules
-		(tr.include_country IS NULL OR $2 = ANY(tr.include_country))
-		AND (tr.include_os IS NULL OR $3 = ANY(tr.include_os))
-		AND (tr.include_app IS NULL OR $1 = ANY(tr.include_app))
-		-- Check exclude rules
-		AND (tr.exclude_country IS NULL OR NOT ($2 = ANY(tr.exclude_country)))
-		AND (tr.exclude_os IS NULL OR NOT ($3 = ANY(tr.exclude_os)))
-		AND (tr.exclude_app IS NULL OR NOT ($1 = ANY(tr.exclude_app)))
-	  )
-	ORDER BY c.cid
-	`
-
 	start := time.Now()
-	rows, err := db.Query(query, app, country, os)
+	rows, err := db.QueryContext(ctx, matchQuery, app, country, os)
 	if err != nil {
 		return nil, err
 	}
@@ -58,24 +54,21 @@ func GetMatchingCampaigns(db *sql.DB, app, country, os string) ([]models.Campaig
 	return campaigns, nil
 }
 
-// GetCampaignByID retrieves a single campaign by ID
-func GetCampaignByID(db *sql.DB, campaignID string) (*models.Campaign, error) {
+func GetCampaignByID(ctx context.Context, db *sql.DB, campaignID string) (*models.Campaign, error) {
 	query := `SELECT cid, name, img, cta, status FROM campaigns WHERE cid = $1`
 
 	var c models.Campaign
-	err := db.QueryRow(query, campaignID).Scan(&c.ID, &c.Name, &c.Img, &c.CTA, &c.Status)
+	err := db.QueryRowContext(ctx, query, campaignID).Scan(&c.ID, &c.Name, &c.Img, &c.CTA, &c.Status)
 	if err != nil {
 		return nil, err
 	}
-
 	return &c, nil
 }
 
-// GetAllActiveCampaigns retrieves all active campaigns
-func GetAllActiveCampaigns(db *sql.DB) ([]models.Campaign, error) {
+func GetAllActiveCampaigns(ctx context.Context, db *sql.DB) ([]models.Campaign, error) {
 	query := `SELECT cid, name, img, cta, status FROM campaigns WHERE status = 'ACTIVE' ORDER BY cid`
 
-	rows, err := db.Query(query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/campaigns/campaign_store_test.go
+++ b/internal/campaigns/campaign_store_test.go
@@ -1,6 +1,7 @@
 package campaigns
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestGetMatchingCampaigns(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			campaigns, err := GetMatchingCampaigns(db, tc.app, tc.country, tc.os)
+			campaigns, err := GetMatchingCampaigns(context.Background(), db, tc.app, tc.country, tc.os)
 			require.NoError(t, err)
 
 			// Extract campaign IDs
@@ -121,7 +122,7 @@ func TestGetCampaignByID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			campaign, err := GetCampaignByID(db, tc.campaignID)
+			campaign, err := GetCampaignByID(context.Background(), db, tc.campaignID)
 
 			if tc.shouldExist {
 				require.NoError(t, err)
@@ -149,7 +150,7 @@ func TestGetAllActiveCampaigns(t *testing.T) {
 		t.Skip("Cannot connect to database, skipping campaign store tests")
 	}
 
-	campaigns, err := GetAllActiveCampaigns(db)
+	campaigns, err := GetAllActiveCampaigns(context.Background(), db)
 	require.NoError(t, err)
 
 	// Should have at least the seeded campaigns

--- a/internal/delivery/handler.go
+++ b/internal/delivery/handler.go
@@ -29,7 +29,7 @@ func HandleDeliveryRequest(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		matched, err := campaigns.GetMatchingCampaigns(db, req.App, req.Country, req.OS)
+		matched, err := campaigns.GetMatchingCampaigns(r.Context(), db, req.App, req.Country, req.OS)
 		if err != nil {
 			slog.ErrorContext(r.Context(), "delivery query failed", "req_id", reqID, "err", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/endpoints/delivery.go
+++ b/internal/endpoints/delivery.go
@@ -31,7 +31,7 @@ import (
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		start := time.Now()
 		req := request.(DeliveryRequest)
-		campaigns, err := svc.Deliver(req.App, req.Country, req.OS)
+		campaigns, err := svc.Deliver(ctx, req.App, req.Country, req.OS)
 		status := "ok"
 		if err != nil {
 			status = "error"

--- a/internal/service/delivery_service.go
+++ b/internal/service/delivery_service.go
@@ -1,25 +1,25 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/campaigns"
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/models"
 )
 
-// DeliveryService defines the business logic for campaign delivery
- type DeliveryService interface {
-	Deliver(app, country, os string) ([]models.Campaign, error)
- }
+type DeliveryService interface {
+	Deliver(ctx context.Context, app, country, os string) ([]models.Campaign, error)
+}
 
- type deliveryService struct {
+type deliveryService struct {
 	db *sql.DB
- }
+}
 
- func NewDeliveryService(db *sql.DB) DeliveryService {
+func NewDeliveryService(db *sql.DB) DeliveryService {
 	return &deliveryService{db: db}
- }
+}
 
- func (s *deliveryService) Deliver(app, country, os string) ([]models.Campaign, error) {
-	return campaigns.GetMatchingCampaigns(s.db, app, country, os)
- }
+func (s *deliveryService) Deliver(ctx context.Context, app, country, os string) ([]models.Campaign, error) {
+	return campaigns.GetMatchingCampaigns(ctx, s.db, app, country, os)
+}


### PR DESCRIPTION
- queries used db.Query with no context, so chi's request timeout never reached postgres
- swap to QueryContext through handler, service, endpoint
- tune the pool: max open 25, idle 10, max lifetime 30m, idle 5m, all env-overridable