### PR TITLE
gin indexes and @> probe

### DIFF
--- a/db/migrations/init.sql
+++ b/db/migrations/init.sql
@@ -19,6 +19,14 @@ CREATE TABLE IF NOT EXISTS targeting_rules (
     exclude_app TEXT[]
 );
 
--- Create indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_campaigns_status ON campaigns(status);
 CREATE INDEX IF NOT EXISTS idx_targeting_rules_cid ON targeting_rules(cid);
+
+-- GIN indexes power the @> (array contains) probes used by the matcher.
+-- Without these, every match scans the whole rules table.
+CREATE INDEX IF NOT EXISTS idx_targeting_rules_include_country ON targeting_rules USING GIN (include_country);
+CREATE INDEX IF NOT EXISTS idx_targeting_rules_exclude_country ON targeting_rules USING GIN (exclude_country);
+CREATE INDEX IF NOT EXISTS idx_targeting_rules_include_os      ON targeting_rules USING GIN (include_os);
+CREATE INDEX IF NOT EXISTS idx_targeting_rules_exclude_os      ON targeting_rules USING GIN (exclude_os);
+CREATE INDEX IF NOT EXISTS idx_targeting_rules_include_app     ON targeting_rules USING GIN (include_app);
+CREATE INDEX IF NOT EXISTS idx_targeting_rules_exclude_app     ON targeting_rules USING GIN (exclude_app);

--- a/internal/campaigns/campaign_store.go
+++ b/internal/campaigns/campaign_store.go
@@ -15,12 +15,12 @@ SELECT DISTINCT c.cid, c.name, c.img, c.cta, c.status
 FROM campaigns c
 JOIN targeting_rules tr ON c.cid = tr.cid
 WHERE c.status = 'ACTIVE'
-  AND (tr.include_country IS NULL OR $2 = ANY(tr.include_country))
-  AND (tr.include_os      IS NULL OR $3 = ANY(tr.include_os))
-  AND (tr.include_app     IS NULL OR $1 = ANY(tr.include_app))
-  AND (tr.exclude_country IS NULL OR NOT ($2 = ANY(tr.exclude_country)))
-  AND (tr.exclude_os      IS NULL OR NOT ($3 = ANY(tr.exclude_os)))
-  AND (tr.exclude_app     IS NULL OR NOT ($1 = ANY(tr.exclude_app)))
+  AND (tr.include_country IS NULL OR tr.include_country @> ARRAY[$2]::text[])
+  AND (tr.include_os      IS NULL OR tr.include_os      @> ARRAY[$3]::text[])
+  AND (tr.include_app     IS NULL OR tr.include_app     @> ARRAY[$1]::text[])
+  AND (tr.exclude_country IS NULL OR NOT (tr.exclude_country @> ARRAY[$2]::text[]))
+  AND (tr.exclude_os      IS NULL OR NOT (tr.exclude_os      @> ARRAY[$3]::text[]))
+  AND (tr.exclude_app     IS NULL OR NOT (tr.exclude_app     @> ARRAY[$1]::text[]))
 ORDER BY c.cid
 `
 


### PR DESCRIPTION
- gin indexes on the six include/exclude array columns
- swap = ANY for @> ARRAY[..]::text[] which is what GIN serves
- the IS NULL OR @> wrapper still blocks index use at small row counts; that's a data-model tradeoff (NULL = no constraint) i'll discuss in the readme pass