### PR TITLE
tests for v2 and endpoint

### DIFF
--- a/internal/endpoints/delivery_test.go
+++ b/internal/endpoints/delivery_test.go
@@ -1,0 +1,46 @@
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/arunbajpai35/greedygame-targeting-engine/internal/models"
+)
+
+type fakeService struct {
+	out []models.Campaign
+	err error
+}
+
+func (f fakeService) Deliver(_ context.Context, _, _, _ string) ([]models.Campaign, error) {
+	return f.out, f.err
+}
+
+func TestDeliveryEndpoint_OK(t *testing.T) {
+	svc := fakeService{out: []models.Campaign{{ID: "spotify", Name: "Spotify"}}}
+	resp, err := MakeDeliveryEndpoint(svc)(context.Background(), DeliveryRequest{App: "x", Country: "us", OS: "android"})
+	assert.NoError(t, err)
+	r := resp.(DeliveryResponse)
+	assert.Empty(t, r.Err)
+	assert.Len(t, r.Campaigns, 1)
+	assert.Equal(t, "spotify", r.Campaigns[0].ID)
+}
+
+func TestDeliveryEndpoint_Empty(t *testing.T) {
+	svc := fakeService{out: nil}
+	resp, _ := MakeDeliveryEndpoint(svc)(context.Background(), DeliveryRequest{})
+	r := resp.(DeliveryResponse)
+	assert.Empty(t, r.Err)
+	assert.Empty(t, r.Campaigns)
+}
+
+func TestDeliveryEndpoint_Error(t *testing.T) {
+	svc := fakeService{err: errors.New("boom")}
+	resp, err := MakeDeliveryEndpoint(svc)(context.Background(), DeliveryRequest{})
+	assert.NoError(t, err, "endpoint must not surface internal errors as transport errors")
+	r := resp.(DeliveryResponse)
+	assert.Equal(t, "internal server error", r.Err)
+}

--- a/internal/transport/http/v2_test.go
+++ b/internal/transport/http/v2_test.go
@@ -1,0 +1,71 @@
+package httptransport
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/arunbajpai35/greedygame-targeting-engine/internal/endpoints"
+	"github.com/arunbajpai35/greedygame-targeting-engine/internal/service"
+)
+
+const testDBConnStr = "postgres://postgres:password@localhost:5432/targeting_db?sslmode=disable"
+
+func newRouter(t *testing.T) (chi.Router, func()) {
+	t.Helper()
+	db, err := sql.Open("postgres", testDBConnStr)
+	if err != nil {
+		t.Skip("db not available")
+	}
+	if err := db.Ping(); err != nil {
+		t.Skip("db unreachable")
+	}
+	svc := service.NewDeliveryService(db)
+	eps := endpoints.Endpoints{Delivery: endpoints.MakeDeliveryEndpoint(svc)}
+	r := chi.NewRouter()
+	RegisterV2Routes(r, eps)
+	return r, func() { db.Close() }
+}
+
+func TestV2Delivery_Match(t *testing.T) {
+	r, cleanup := newRouter(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/delivery?app=com.gametion.ludokinggame&country=us&os=android", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "spotify")
+	assert.Contains(t, w.Body.String(), "subwaysurfer")
+	assert.NotContains(t, w.Body.String(), `"status"`, "status must not leak to the wire")
+}
+
+func TestV2Delivery_NoMatch(t *testing.T) {
+	r, cleanup := newRouter(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/delivery?app=com.test&country=zz&os=web", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String())
+}
+
+func TestV2Delivery_CaseInsensitive(t *testing.T) {
+	r, cleanup := newRouter(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/delivery?app=COM.GAMETION.LUDOKINGGAME&country=US&os=ANDROID", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "spotify")
+}


### PR DESCRIPTION
- v2 had no tests at all; now covers match, no-match (204), and case-insensitive
- endpoint covered with a fake service so error/empty/ok branches don't need a db
- v2 still doesn't 400 on missing params the way v1 does — separate fix