### PR TITLE
v2 validates missing params

### DIFF
--- a/internal/transport/http/v2.go
+++ b/internal/transport/http/v2.go
@@ -3,6 +3,7 @@ package httptransport
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -12,34 +13,63 @@ import (
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/endpoints"
 )
 
+type badRequestError struct{ msg string }
+
+func (e badRequestError) Error() string { return e.msg }
+
 func RegisterV2Routes(r chi.Router, eps endpoints.Endpoints) {
 	server := kithttp.NewServer(
 		eps.Delivery,
 		decodeDeliveryRequest,
 		encodeDeliveryResponse,
+		kithttp.ServerErrorEncoder(encodeError),
 	)
-
 	r.Get("/v2/delivery", server.ServeHTTP)
 }
 
 func decodeDeliveryRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	app := strings.TrimSpace(r.URL.Query().Get("app"))
-	country := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("country")))
-	os := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("os")))
-	return endpoints.DeliveryRequest{App: app, Country: country, OS: os}, nil
+	country := strings.TrimSpace(r.URL.Query().Get("country"))
+	os := strings.TrimSpace(r.URL.Query().Get("os"))
+
+	switch {
+	case app == "":
+		return nil, badRequestError{"missing app param"}
+	case country == "":
+		return nil, badRequestError{"missing country param"}
+	case os == "":
+		return nil, badRequestError{"missing os param"}
+	}
+
+	return endpoints.DeliveryRequest{
+		App:     strings.ToLower(app),
+		Country: strings.ToLower(country),
+		OS:      strings.ToLower(os),
+	}, nil
 }
 
-func encodeDeliveryResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+func encodeDeliveryResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	w.Header().Set("Content-Type", "application/json")
 	resp := response.(endpoints.DeliveryResponse)
-	// On empty campaigns, align with v1 behavior and return 204
-	if resp.Err == "" && len(resp.Campaigns) == 0 {
-		w.WriteHeader(http.StatusNoContent)
-		return nil
-	}
 	if resp.Err != "" {
 		w.WriteHeader(http.StatusInternalServerError)
 		return json.NewEncoder(w).Encode(map[string]string{"error": resp.Err})
 	}
+	if len(resp.Campaigns) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return nil
+	}
 	return json.NewEncoder(w).Encode(resp.Campaigns)
+}
+
+func encodeError(_ context.Context, err error, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	var br badRequestError
+	if errors.As(err, &br) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": br.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusInternalServerError)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": "internal server error"})
 }

--- a/internal/transport/http/v2_test.go
+++ b/internal/transport/http/v2_test.go
@@ -58,6 +58,28 @@ func TestV2Delivery_NoMatch(t *testing.T) {
 	assert.Empty(t, w.Body.String())
 }
 
+func TestV2Delivery_MissingParams(t *testing.T) {
+	r, cleanup := newRouter(t)
+	defer cleanup()
+
+	cases := []struct {
+		name, query, msg string
+	}{
+		{"missing app", "/v2/delivery?country=us&os=android", "missing app param"},
+		{"missing country", "/v2/delivery?app=x&os=android", "missing country param"},
+		{"missing os", "/v2/delivery?app=x&country=us", "missing os param"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, c.query, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.JSONEq(t, `{"error":"`+c.msg+`"}`, w.Body.String())
+		})
+	}
+}
+
 func TestV2Delivery_CaseInsensitive(t *testing.T) {
 	r, cleanup := newRouter(t)
 	defer cleanup()


### PR DESCRIPTION
- v2 was passing empty strings through to the matcher and returning 204
- now matches v1: 400 with {error: missing X param}
- wire a kit ServerErrorEncoder so badRequestError returns 400, anything else 500