### PR TITLE
reload on listener reconnect

### DIFF
--- a/internal/cache/listener.go
+++ b/internal/cache/listener.go
@@ -12,9 +12,23 @@ import (
 const NotifyChannel = "targeting_changes"
 
 func StartListener(ctx context.Context, c *Cache, db *sql.DB, connStr string, debounce time.Duration) error {
-	l := pq.NewListener(connStr, 5*time.Second, time.Minute, func(ev pq.ListenerEventType, err error) {
-		if err != nil {
-			slog.Warn("listener event", "type", ev, "err", err)
+	reload := make(chan struct{}, 1)
+	trigger := func(reason string) {
+		slog.Info("cache reload requested", "reason", reason)
+		select {
+		case reload <- struct{}{}:
+		default:
+		}
+	}
+
+	l := pq.NewListener(connStr, 5*time.Second, 30*time.Second, func(ev pq.ListenerEventType, err error) {
+		switch ev {
+		case pq.ListenerEventConnected, pq.ListenerEventReconnected:
+			trigger("listener (re)connected")
+		case pq.ListenerEventDisconnected:
+			slog.Warn("listener disconnected", "err", err)
+		case pq.ListenerEventConnectionAttemptFailed:
+			slog.Warn("listener connect attempt failed", "err", err)
 		}
 	})
 	if err := l.Listen(NotifyChannel); err != nil {
@@ -25,6 +39,8 @@ func StartListener(ctx context.Context, c *Cache, db *sql.DB, connStr string, de
 		defer l.Close()
 		var pending bool
 		var timer *time.Timer
+		ping := time.NewTicker(20 * time.Second)
+		defer ping.Stop()
 
 		fire := func() {
 			pending = false
@@ -37,6 +53,14 @@ func StartListener(ctx context.Context, c *Cache, db *sql.DB, connStr string, de
 			cancel()
 		}
 
+		schedule := func() {
+			if pending {
+				return
+			}
+			pending = true
+			timer = time.AfterFunc(debounce, fire)
+		}
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -45,12 +69,10 @@ func StartListener(ctx context.Context, c *Cache, db *sql.DB, connStr string, de
 				}
 				return
 			case <-l.Notify:
-				if pending {
-					continue
-				}
-				pending = true
-				timer = time.AfterFunc(debounce, fire)
-			case <-time.After(time.Minute):
+				schedule()
+			case <-reload:
+				schedule()
+			case <-ping.C:
 				_ = l.Ping()
 			}
 		}


### PR DESCRIPTION
- on neon free tier, compute scales to zero between requests; the listener's long-lived connection drops and any NOTIFY fired during the gap is lost
- now the listener event callback triggers a full reload on Connected and Reconnected, so a missed window self-heals
- ping interval down to 20s so disconnect is detected sooner