### PR TITLE
hmac auth on delivery routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The earlier SQL-per-request implementation lived in an `internal/campaigns` pack
 | `DB_MAX_IDLE_CONNS` | 10 | |
 | `APPLY_SEED` | `false` | If `true`, the embedded `seed.sql` runs on boot. Idempotent. |
 | `PORT` | `8080` | Render and similar PaaS inject this. |
+| `API_SECRET` | unset | If set, `/v1/delivery` and `/v2/delivery` require an HMAC-signed request. `/healthz`, `/readyz`, `/metrics` stay open. |
 
 Schema lives in `internal/migrate/sql/` and is embedded into the binary; `init.sql` runs on every boot, `seed.sql` only when `APPLY_SEED=true`.
 
@@ -85,6 +86,28 @@ Wiring it up yourself:
 1. **Neon**: create a project, copy the **direct** connection string — *not* the pooled one. The pooled hostname has `-pooler` in it; PgBouncer in transaction mode silently drops `LISTEN/NOTIFY`, so cache invalidation breaks. The pooled URL still works for everything else, which makes it especially nasty to debug.
 2. **Render**: New → Web Service → connect this repo. Runtime: Docker. Plan: free. Region: pick the same one as Neon. Env vars: `DATABASE_URL` (the direct URL from step 1), `APPLY_SEED=true` for the first deploy (flip to `false` afterwards). Render auto-injects `PORT`.
 3. First boot applies the schema and seed; subsequent boots only apply the schema.
+
+## Auth
+
+The delivery endpoints are open by default so the live demo is easy to poke at. Setting `API_SECRET` flips on HMAC auth.
+
+Request must carry:
+
+- `X-Timestamp: <unix seconds>` — rejected if more than 5 minutes off server time
+- `X-Signature: hex(hmac_sha256(secret, payload))`
+
+Where `payload` is `<timestamp>\n<method>\n<path>\n<sorted-query>`. Query is `k=v` pairs joined with `&`, keys sorted alphabetically. Example:
+
+```bash
+SECRET=...
+TS=$(date +%s)
+PAYLOAD=$(printf "%s\nGET\n/v1/delivery\napp=com.gametion.ludokinggame&country=us&os=android" "$TS")
+SIG=$(printf "%s" "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk '{print $NF}')
+curl -H "X-Timestamp: $TS" -H "X-Signature: $SIG" \
+  "http://localhost:8080/v1/delivery?app=com.gametion.ludokinggame&country=us&os=android"
+```
+
+The signature is checked with constant-time compare. Replay protection is the timestamp window — a captured request is useless after 5 minutes.
 
 ## Observability
 
@@ -114,5 +137,4 @@ The matcher is a linear walk over the snapshot, so cost grows with rule count. F
 
 ## What's missing / what i'd do next
 
-- Auth on `/v1/delivery` (the take-home brief didn't ask, but a real ad-serving endpoint shouldn't be open).
 - Multi-instance cache coordination — the LISTEN/NOTIFY model fans out fine, but two replicas reload independently, which is wasteful at scale. A delta channel or a versioned snapshot pull would fix it.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/arunbajpai35/greedygame-targeting-engine/internal/auth"
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/cache"
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/delivery"
 	"github.com/arunbajpai35/greedygame-targeting-engine/internal/endpoints"
@@ -88,13 +89,19 @@ func main() {
 	r.Get("/readyz", readiness(db))
 	r.Handle("/metrics", promhttp.Handler())
 
-	r.Route("/v1", func(r chi.Router) {
-		r.Get("/delivery", delivery.HandleDeliveryRequest(cch))
-	})
+	apiAuth := auth.RequireHMAC(os.Getenv("API_SECRET"))
+	if os.Getenv("API_SECRET") != "" {
+		logger.Info("hmac auth enabled on delivery routes")
+	}
 
-	svc := service.NewDeliveryService(cch)
-	eps := endpoints.Endpoints{Delivery: endpoints.MakeDeliveryEndpoint(svc)}
-	transport.RegisterV2Routes(r, eps)
+	r.Group(func(r chi.Router) {
+		r.Use(apiAuth)
+		r.Get("/v1/delivery", delivery.HandleDeliveryRequest(cch))
+
+		svc := service.NewDeliveryService(cch)
+		eps := endpoints.Endpoints{Delivery: endpoints.MakeDeliveryEndpoint(svc)}
+		transport.RegisterV2Routes(r, eps)
+	})
 
 	srv := &http.Server{
 		Addr:         ":" + getEnv("PORT", "8080"),

--- a/internal/auth/hmac.go
+++ b/internal/auth/hmac.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MaxClockSkew bounds how stale a request timestamp can be. Five minutes is
+// generous enough to tolerate clock drift but tight enough that captured
+// requests can't be replayed indefinitely.
+const MaxClockSkew = 5 * time.Minute
+
+func RequireHMAC(secret string) func(http.Handler) http.Handler {
+	if secret == "" {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	key := []byte(secret)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := verify(r, key, time.Now()); err != "" {
+				http.Error(w, err, http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func verify(r *http.Request, key []byte, now time.Time) string {
+	tsHeader := r.Header.Get("X-Timestamp")
+	sigHeader := r.Header.Get("X-Signature")
+	if tsHeader == "" || sigHeader == "" {
+		return "missing X-Timestamp or X-Signature"
+	}
+	ts, err := strconv.ParseInt(tsHeader, 10, 64)
+	if err != nil {
+		return "invalid X-Timestamp"
+	}
+	if drift := now.Unix() - ts; drift > int64(MaxClockSkew/time.Second) || drift < -int64(MaxClockSkew/time.Second) {
+		return "timestamp outside allowed window"
+	}
+	sig, err := hex.DecodeString(sigHeader)
+	if err != nil {
+		return "invalid X-Signature encoding"
+	}
+	want := sign(key, tsHeader, r.Method, r.URL.Path, r.URL.Query())
+	if !hmac.Equal(sig, want) {
+		return "signature mismatch"
+	}
+	return ""
+}
+
+// Sign builds the canonical payload and returns the hex signature. Exposed so
+// clients (and tests) can produce matching signatures without re-deriving the
+// payload format.
+func Sign(secret, ts, method, path string, query map[string][]string) string {
+	return hex.EncodeToString(sign([]byte(secret), ts, method, path, query))
+}
+
+func sign(key []byte, ts, method, path string, query map[string][]string) []byte {
+	keys := make([]string, 0, len(query))
+	for k := range query {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(ts)
+	b.WriteByte('\n')
+	b.WriteString(method)
+	b.WriteByte('\n')
+	b.WriteString(path)
+	b.WriteByte('\n')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		vs := query[k]
+		sort.Strings(vs)
+		for j, v := range vs {
+			if j > 0 {
+				b.WriteByte('&')
+			}
+			b.WriteString(k)
+			b.WriteByte('=')
+			b.WriteString(v)
+		}
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(b.String()))
+	return mac.Sum(nil)
+}

--- a/internal/auth/hmac_test.go
+++ b/internal/auth/hmac_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const secret = "test-secret"
+
+func signedReq(t *testing.T, ts time.Time, secret string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/v1/delivery?app=foo&country=us&os=android", nil)
+	tsStr := strconv.FormatInt(ts.Unix(), 10)
+	r.Header.Set("X-Timestamp", tsStr)
+	r.Header.Set("X-Signature", Sign(secret, tsStr, http.MethodGet, r.URL.Path, r.URL.Query()))
+	return r
+}
+
+func handler200() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestRequireHMAC_Disabled(t *testing.T) {
+	mw := RequireHMAC("")
+	r := httptest.NewRequest(http.MethodGet, "/v1/delivery?app=foo", nil)
+	w := httptest.NewRecorder()
+	mw(handler200()).ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireHMAC_ValidSignature(t *testing.T) {
+	mw := RequireHMAC(secret)
+	r := signedReq(t, time.Now(), secret)
+	w := httptest.NewRecorder()
+	mw(handler200()).ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireHMAC_MissingHeaders(t *testing.T) {
+	mw := RequireHMAC(secret)
+	r := httptest.NewRequest(http.MethodGet, "/v1/delivery?app=foo", nil)
+	w := httptest.NewRecorder()
+	mw(handler200()).ServeHTTP(w, r)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "missing")
+}
+
+func TestRequireHMAC_WrongSecret(t *testing.T) {
+	mw := RequireHMAC(secret)
+	r := signedReq(t, time.Now(), "different-secret")
+	w := httptest.NewRecorder()
+	mw(handler200()).ServeHTTP(w, r)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "signature mismatch")
+}
+
+func TestRequireHMAC_StaleTimestamp(t *testing.T) {
+	mw := RequireHMAC(secret)
+	r := signedReq(t, time.Now().Add(-10*time.Minute), secret)
+	w := httptest.NewRecorder()
+	mw(handler200()).ServeHTTP(w, r)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "outside allowed window")
+}
+
+func TestRequireHMAC_QueryOrderInvariant(t *testing.T) {
+	mw := RequireHMAC(secret)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	r := httptest.NewRequest(http.MethodGet, "/v1/delivery?os=android&country=us&app=foo", nil)
+	r.Header.Set("X-Timestamp", ts)
+	r.Header.Set("X-Signature", Sign(secret, ts, http.MethodGet, "/v1/delivery", map[string][]string{
+		"app": {"foo"}, "country": {"us"}, "os": {"android"},
+	}))
+	w := httptest.NewRecorder()
+	mw(handler200()).ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code, "signature should be order-invariant")
+}


### PR DESCRIPTION
- API_SECRET enables hmac-sha256 over (timestamp, method, path, sorted query); empty secret = open (default, keeps live demo accessible)
- 5min timestamp window for replay protection, hmac.Equal for constant-time compare
- only /v1/delivery and /v2/delivery; healthz, readyz, metrics stay open
- readme has a copy-paste curl example with openssl